### PR TITLE
Fix thumbnail display in the recordings preview

### DIFF
--- a/bbb-lti/grails-app/assets/stylesheets/tool.css
+++ b/bbb-lti/grails-app/assets/stylesheets/tool.css
@@ -3,12 +3,9 @@
     padding: 4px;
     width: 66px;
     float: left;
+    transition: all .1s linear
 }
 
 .thumbnail:hover {
-    display: inline-block;
-    height: auto;
-    position: absolute;
-    width: auto;
-    z-index: 99999;
+    transform: scale(2.0)
 }

--- a/bbb-lti/grails-app/controllers/org/bigbluebutton/ToolController.groovy
+++ b/bbb-lti/grails-app/controllers/org/bigbluebutton/ToolController.groovy
@@ -352,7 +352,24 @@ class ToolController {
         if (format.preview.images.image instanceof Map<?,?>) {
             return new ArrayList(format.preview.images.image)
         }
-        return format.preview.images.image
+
+        if (format.preview.images.image instanceof ArrayList) {
+            def images = new ArrayList<Object>()
+
+            for (Object item : format.preview.images.image) {
+                if(item instanceof ArrayList && item.size() > 0) {
+                    images.add(item[0])
+                }
+                if(item instanceof Map<?, ?>) {
+                    images.add(item)
+                }
+            }
+
+            return images
+        }
+
+        // By default leave it empty
+        return new ArrayList()
     }
 
     private String getCartridgeXML(){


### PR DESCRIPTION
This fixes the display of thumbnails in the lti based clients which
were not parsing properly according to the image preview getRecordings API.